### PR TITLE
replacing usb camera library

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -28,5 +28,5 @@ dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
     implementation "com.facebook.react:react-native:${_reactNativeVersion}"  // From node_modules
     implementation 'com.opentok.android:opentok-android-sdk:2.20.1'
-    implementation 'com.github.jiangdongguo:AndroidUSBCamera:2.3.4'
+    implementation 'com.github.gab07:AndroidUSBCamera:2.3.7'
 }


### PR DESCRIPTION
replaced usb camera library with our [fork](https://github.com/gab07/AndroidUSBCamera) that fixes a crash when the camera gets unplugged