### PR TITLE
React 18 fix

### DIFF
--- a/@types/index.d.ts
+++ b/@types/index.d.ts
@@ -377,6 +377,8 @@ declare module "opentok-react-native" {
      * If set to true, the subscriber can subscribe to it's own publisher stream (default: false)
      */
     subscribeToSelf?: boolean;
+
+    children?: CallbackWithParam<string[], void>; 
   }
 
   interface OTSubscriberProperties {

--- a/android/src/main/java/com/opentokreactnative/OTSessionManager.java
+++ b/android/src/main/java/com/opentokreactnative/OTSessionManager.java
@@ -598,7 +598,6 @@ public class OTSessionManager extends ReactContextBaseJavaModule
         ConcurrentHashMap<String, Boolean> destroyedStreams = sharedState.getPublisherDestroyedStreams();
         boolean streamWasDestroyed = destroyedStreams.containsKey(streamId);
         if (streamWasDestroyed) {
-            destroyedStreams.remove(streamId);
             return;
         }
         ConcurrentHashMap<String, Stream> mSubscriberStreams = sharedState.getSubscriberStreams();


### PR DESCRIPTION
- Added children prop to Subscriber props since the default children props was removed in React.
- Keep the tracking of destroyed stream in case we receive them again.